### PR TITLE
Improve client-server file transfer in metacom

### DIFF
--- a/applications/metarhia.com/api/metacom/downloadFile.js
+++ b/applications/metarhia.com/api/metacom/downloadFile.js
@@ -23,7 +23,7 @@
 
   readStream.on('error', (error) => {
     if (!isOpen) {
-      return callback(api.metacom.errors.ERR_NO_SUCH_FILE);
+      callback(api.metacom.errors.ERR_NO_SUCH_FILE);
     }
     application.log.error(
       `In metacom.downloadFile on reading the file: ${error}`

--- a/applications/metarhia.com/api/metacom/endFileUpload.js
+++ b/applications/metarhia.com/api/metacom/endFileUpload.js
@@ -1,7 +1,7 @@
 (callback) => {
-  if (!connection.upload) {
+  if (!connection.isUploading) {
     return callback(api.metacom.errors.ERR_UPLOAD_NOT_STARTED);
   }
-  connection.upload = false;
+  connection.fileStream.end();
   callback(null, connection.uploadCode.join(''));
 }

--- a/applications/metarhia.com/api/metacom/uploadFileChunk.js
+++ b/applications/metarhia.com/api/metacom/uploadFileChunk.js
@@ -4,20 +4,36 @@
     return callback(api.jstp.ERR_INVALID_SIGNATURE);
   }
 
-  if (!connection.upload) {
-    connection.upload = true;
-    connection.uploadBuffer = '';
-    connection.uploadStream = new api.stream.Readable({
-      read() {
-        let canPushMore = true;
-        canPushMore = this.push(connection.uploadBuffer, 'base64');
-        connection.uploadBuffer = '';
-        if (!connection.upload && canPushMore) {
-          this.push(null);
-        }
-      }
-    });
+  if (connection.isUploadingRightNow) {
+    return callback(api.metacom.errors.ERR_PREVIOUS_UPLOAD_NOT_FINISHED);
+  }
 
+  connection.isUploadingRightNow = true;
+
+  function finishChunkUpload() {
+    connection.isUploadingRightNow = false;
+    callback();
+  }
+
+  function writeChunkToFileWriteStream() {
+    if (!connection.fileStream.write(chunk)) {
+      connection.fileStream.on('drain', finishChunkUpload);
+    } else {
+      finishChunkUpload();
+    }
+  }
+
+  function finishUpload() {
+    connection.fileStream = null;
+    connection.isUploading = false;
+    connection.removeListener('close', connectionCloseListener);
+  }
+
+  function connectionCloseListener() {
+    connection.fileStream.end();
+  }
+
+  if (!connection.isUploading) {
     connection.uploadCode = api.metacom.generateFileCode();
     const uploadDir = api.path.join(
       application.dir,
@@ -27,13 +43,33 @@
     );
 
     api.mkdirp(uploadDir, () => {
-      connection.uploadStream.pipe(api.fs.createWriteStream(
-        api.path.join(uploadDir, connection.uploadCode[2])
-      ));
+      connection.fileStream = api.fs.createWriteStream(
+        api.path.join(uploadDir, connection.uploadCode[2]),
+        'base64'
+      );
+
+      connection.fileStream.on('error', (error) => {
+        application.log.error(
+          `In uploadFileChunk on file WriteStream: ${error}`
+        );
+        finishUpload();
+      });
+
+      const creationErrorListener = () =>
+        callback(api.jstp.ERR_INTERNAL_API_ERROR);
+      connection.fileStream.once('error', creationErrorListener);
+
+      connection.fileStream.once('open', () => {
+        connection.fileStream.removeListener('error', creationErrorListener);
+        connection.isUploading = true;
+        connection.once('close', connectionCloseListener);
+        writeChunkToFileWriteStream();
+      });
+
+      connection.fileStream.once('finish', finishUpload);
+
     });
+  } else {
+    writeChunkToFileWriteStream();
   }
-
-  connection.uploadBuffer += chunk;
-
-  callback();
 }

--- a/applications/metarhia.com/lib/metacom.js
+++ b/applications/metarhia.com/lib/metacom.js
@@ -5,7 +5,8 @@ api.metacom.errors = Object.assign(Object.create(null), {
   ERR_NOT_IN_CHAT: 31,
   ERR_NO_INTERLOCUTOR: 32,
   ERR_NO_SUCH_FILE: 33,
-  ERR_UPLOAD_NOT_STARTED: 34
+  ERR_UPLOAD_NOT_STARTED: 34,
+  ERR_PREVIOUS_UPLOAD_NOT_FINISHED: 35
 });
 
 api.metacom.chats = new Map();

--- a/doc/metacom.md
+++ b/doc/metacom.md
@@ -10,7 +10,7 @@
 | Start file transfer in chat | `startChatFileTransfer` | `mimeType: String` | None | `ERR_NOT_IN_CHAT` (31), `ERR_NO_INTERLOCUTOR` (32) |
 | Send next file chunk in chat | `sendFileChunkToChat` | `chunk: String` | None | `ERR_NOT_IN_CHAT` (31), `ERR_NO_INTERLOCUTOR` (32) |
 | End file transfer in chat | `endChatFileTransfer` | None | None | `ERR_NOT_IN_CHAT` (31), `ERR_NO_INTERLOCUTOR` (32) |
-| Upload next file chunk to server | `uploadFileChunk` | `chunk: String` | None | None |
+| Upload next file chunk to server | `uploadFileChunk` | `chunk: String` | None | `ERR_PREVIOUS_UPLOAD_NOT_FINISHED (35)` |
 | End file upload to server | `endFileUpload` | None | `code: String` | `ERR_UPLOAD_NOT_STARTED (34)` |
 | Start file download | `downloadFile` | `code: String` | None | `ERR_NO_SUCH_FILE` (33) |
 
@@ -37,6 +37,7 @@
 | 32   | `ERR_NO_INTERLOCUTOR` | Occurs when user is the only one person in the room. |
 | 33   | `ERR_NO_SUCH_FILE` | Occurs when user tries to download file with incorrect code. |
 | 34   | `ERR_UPLOAD_NOT_STARTED` | Occurs when user tries to finish uploading file to the server without starting it first. |
+| 35   | `ERR_PREVIOUS_UPLOAD_NOT_FINISHED` | Occurs when user tries to upload next file chunk to the server without first receiving callback for the previous chunk. |
 
 ### Additional information
 


### PR DESCRIPTION
* Log file opening errors in `downloadFile` method.
* Make file upload sequential to avoid possible attacks on server
  by flooding the corresponding stream buffer.
* Add error to enforce sequential upload and update the API
  documentation respectively.
* Fix the output stream not being closed on connection close.
* Refactor and optimize file uploading:
  * Remove redundant Readable stream abstraction.
  * Add missing 'error' event listeners to the corresponding
    WriteStream.